### PR TITLE
display_driver: avoid converting pointers to UINT

### DIFF
--- a/common/src/gx_display_driver_32argb_pixelmap_blend.c
+++ b/common/src/gx_display_driver_32argb_pixelmap_blend.c
@@ -89,7 +89,7 @@ GX_RECTANGLE *clip = context -> gx_draw_context_clip;
     put = context -> gx_draw_context_memory + clip -> gx_rectangle_top * context -> gx_draw_context_pitch;
     put += clip -> gx_rectangle_left;
 
-    getrow = (GX_COLOR *)((UINT)(pixelmap -> gx_pixelmap_data) + sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)((INT)(clip -> gx_rectangle_top) - ypos));
+    getrow = (GX_COLOR *)((UCHAR *)(pixelmap -> gx_pixelmap_data) + sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)((INT)(clip -> gx_rectangle_top) - ypos));
     getrow += (clip -> gx_rectangle_left - xpos);
 
     for (yval = clip -> gx_rectangle_top; yval <= clip -> gx_rectangle_bottom; yval++)

--- a/common/src/gx_display_driver_32argb_pixelmap_draw.c
+++ b/common/src/gx_display_driver_32argb_pixelmap_draw.c
@@ -91,7 +91,7 @@ GX_RECTANGLE *clip = context -> gx_draw_context_clip;
     xval = clip -> gx_rectangle_left;
     yval = clip -> gx_rectangle_top;
 
-    get = (ULONG *)((ULONG)pixelmap -> gx_pixelmap_data + (sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)(((INT)(clip -> gx_rectangle_top) - ypos))));
+    get = (ULONG *)((UCHAR *)pixelmap -> gx_pixelmap_data + (sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)(((INT)(clip -> gx_rectangle_top) - ypos))));
     get += (clip -> gx_rectangle_left - xpos);
 
     width = clip -> gx_rectangle_right - clip -> gx_rectangle_left + 1;

--- a/common/src/gx_display_driver_32bpp_pixelmap_draw.c
+++ b/common/src/gx_display_driver_32bpp_pixelmap_draw.c
@@ -171,7 +171,7 @@ GX_RECTANGLE *clip = context -> gx_draw_context_clip;
     xval = clip -> gx_rectangle_left;
     yval = clip -> gx_rectangle_top;
 
-    get = (ULONG *)((UINT)(pixelmap -> gx_pixelmap_data) + (INT)sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)((INT)(clip -> gx_rectangle_top) - ypos));
+    get = (ULONG *)((UCHAR *)(pixelmap -> gx_pixelmap_data) + (INT)sizeof(GX_COLOR) * (UINT)(pixelmap -> gx_pixelmap_width) * (UINT)((INT)(clip -> gx_rectangle_top) - ypos));
     get += (clip -> gx_rectangle_left - xpos);
 
     width = clip -> gx_rectangle_right - clip -> gx_rectangle_left + 1;


### PR DESCRIPTION
Simply use "UCHAR *" instead of UINT, so it can be used on 64bit machine for simulation.