### PR TITLE
gx_canvas_drawing_initiate: Use display driver function to calculate context pitch

### DIFF
--- a/common/src/gx_canvas_drawing_initiate.c
+++ b/common/src/gx_canvas_drawing_initiate.c
@@ -174,18 +174,18 @@ GX_DISPLAY      *display = canvas -> gx_canvas_display;
             }
             else
             {
-                new_context -> gx_draw_context_pitch = canvas -> gx_canvas_x_resolution;
+                new_context -> gx_draw_context_pitch = canvas -> gx_canvas_display -> gx_display_driver_row_pitch_get(canvas -> gx_canvas_x_resolution);
                 new_context -> gx_draw_context_offset_x = 0;
                 new_context -> gx_draw_context_offset_y = 0;
             }
 
 #else
-            new_context -> gx_draw_context_pitch = canvas -> gx_canvas_x_resolution;
+            new_context -> gx_draw_context_pitch = canvas -> gx_canvas_display -> gx_display_driver_row_pitch_get(canvas -> gx_canvas_x_resolution);
 #endif
         }
         else
         {
-            new_context -> gx_draw_context_pitch = canvas -> gx_canvas_y_resolution;
+            new_context -> gx_draw_context_pitch = canvas -> gx_canvas_display -> gx_display_driver_row_pitch_get(canvas -> gx_canvas_y_resolution);
         }
     }
 


### PR DESCRIPTION
While developing EV charger application on Renesas RA6M3, I encountered a row width vs pitch problem in GUIX and Renesas display driver.

The display has resolution 480x272, and MCU-integrated LCD controller requires framebuffer rows to be aligned on 32-byte boundary.

So in this case, the framebuffer pitch is 512 bytes, not 480.

This patch uses possibly driver-supplied function `gx_display_driver_row_pitch_get()` to calculate pitch from width.
