### PR TITLE
replaced _gx_system_lock with GX_ENTER_CRITICAL

### DIFF
--- a/common/src/gx_horizontal_list_total_columns_set.c
+++ b/common/src/gx_horizontal_list_total_columns_set.c
@@ -55,8 +55,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Obtain GUIX system lock       */
-/*    _gx_system_unlock                     Release GUIX system lock      */
+/*    GX_ENTER_CRITICAL                     Obtain GUIX system lock       */
+/*    GX_EXIT_CRITICAL                      Release GUIX system lock      */
 /*    _gx_first_client_child_get            Get the first client child    */
 /*    _gx_window_scrollbar_find             Find the scrollbar            */
 /*    _gx_scrollbar_reset                   Reset the schollbar           */
@@ -85,7 +85,7 @@ INT           index;
 GX_WIDGET    *test;
 GX_SCROLLBAR *pScroll;
 
-    _gx_system_lock();
+    GX_ENTER_CRITICAL
 
     /* Update total count of rows. */
     list -> gx_horizontal_list_total_columns = count;
@@ -183,7 +183,7 @@ GX_SCROLLBAR *pScroll;
         _gx_scrollbar_reset(pScroll, GX_NULL);
     }
 
-    _gx_system_unlock();
+    GX_EXIT_CRITICAL
 
     /* Refresh screen. */
     if (list -> gx_widget_status & GX_STATUS_VISIBLE)

--- a/common/src/gx_system_animation_free.c
+++ b/common/src/gx_system_animation_free.c
@@ -52,8 +52,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*   _gx_system_lock                        lock system mutex             */
-/*   _gx_system_unlock                      unlock system mutex           */
+/*   GX_ENTER_CRITICAL                      lock system mutex             */
+/*   GX_EXIT_CRITICAL                       unlock system mutex           */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_system_animation_get.c
+++ b/common/src/gx_system_animation_get.c
@@ -52,8 +52,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*   _gx_system_lock                        lock system mutex             */
-/*   _gx_system_unlock                      unlock system mutex           */
+/*   GX_ENTER_CRITICAL                      lock system mutex             */
+/*   GX_EXIT_CRITICAL                       unlock system mutex           */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_system_timer_start.c
+++ b/common/src/gx_system_timer_start.c
@@ -56,8 +56,8 @@
 /*  CALLS                                                                 */
 /*                                                                        */
 /*   tx_timer_activate                      start the ThreadX timer       */
-/*   _gx_system_lock                        lock system mutex             */
-/*   _gx_system_unlock                      unlock system mutex           */
+/*   GX_ENTER_CRITICAL                      lock system mutex             */
+/*   GX_EXIT_CRITICAL                       unlock system mutex           */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_system_timer_stop.c
+++ b/common/src/gx_system_timer_stop.c
@@ -53,8 +53,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       lock critical section         */
-/*    _gx_system_unlock                     unlock critical section       */
+/*    GX_ENTER_CRITICAL                     lock critical section         */
+/*    GX_EXIT_CRITICAL                      unlock critical section       */
 /*    tx_timer_deactivate                   stop the ThreadX timer        */
 /*                                                                        */
 /*  CALLED BY                                                             */

--- a/common/src/gx_system_timer_update.c
+++ b/common/src/gx_system_timer_update.c
@@ -54,8 +54,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*   _gx_system_lock                        Lock system mutex             */
-/*   _gx_system_unlock                      Unlock system mutex           */
+/*   GX_ENTER_CRITICAL                      Lock system mutex             */
+/*   GX_EXIT_CRITICAL                       Unlock system mutex           */
 /*   [gx_widget_event_process_function]     Event handler of timer owner  */
 /*   _gx_system_timer_stop                  Stop the system timer         */
 /*   _gx_animation_update                   Update the animation sequence */

--- a/common/src/gx_vertical_list_total_rows_set.c
+++ b/common/src/gx_vertical_list_total_rows_set.c
@@ -55,8 +55,8 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Obtain GUIX system lock       */
-/*    _gx_system_unlock                     Release GUIX system lock      */
+/*    GX_ENTER_CRITICAL                     Obtain GUIX system lock       */
+/*    GX_EXIT_CRITICAL                      Release GUIX system lock      */
 /*    _gx_first_client_child_get            Get the first client child    */
 /*    [gx_vertical_list_callback]           Vertical list callback        */
 /*    _gx_window_scrollbar_find             Find the scrollbar            */
@@ -86,7 +86,7 @@ INT           index;
 GX_WIDGET    *test;
 GX_SCROLLBAR *pScroll;
 
-    _gx_system_lock();
+    GX_ENTER_CRITICAL
 
     /* Update total count of rows. */
     list -> gx_vertical_list_total_rows = count;
@@ -183,7 +183,7 @@ GX_SCROLLBAR *pScroll;
         _gx_scrollbar_reset(pScroll, GX_NULL);
     }
 
-    _gx_system_unlock();
+    GX_EXIT_CRITICAL
 
     /* Refresh screen. */
     if (list -> gx_widget_status & GX_STATUS_VISIBLE)

--- a/common/src/gx_widget_attach.c
+++ b/common/src/gx_widget_attach.c
@@ -55,10 +55,10 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Obtain GUIX system lock       */
+/*    GX_ENTER_CRITICAL                     Obtain GUIX system lock       */
 /*    _gx_widget_detach                     Detach from current parent    */
 /*    _gx_widget_link                       Link widget                   */
-/*    _gx_system_unlock                     Release GUIX system lock      */
+/*    GX_EXIT_CRITICAL                      Release GUIX system lock      */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_widget_back_attach.c
+++ b/common/src/gx_widget_back_attach.c
@@ -55,10 +55,10 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Obtain GUIX system lock       */
+/*    GX_ENTER_CRITICAL                     Obtain GUIX system lock       */
 /*    _gx_widget_detach                     Detach widget                 */
 /*    _gx_widget_back_link                  Link widget in back           */
-/*    _gx_system_unlock                     Release GUIX system lock      */
+/*    GX_EXIT_CRITICAL                      Release GUIX system lock      */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_widget_create.c
+++ b/common/src/gx_widget_create.c
@@ -59,9 +59,9 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Lock access to GUIX           */
+/*    GX_ENTER_CRITICAL                     Lock access to GUIX           */
 /*    _gx_widget_link                       Link a widget to parent       */
-/*    _gx_system_unlock                     Release the protection        */
+/*    GX_EXIT_CRITICAL                      Release the protection        */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_widget_delete.c
+++ b/common/src/gx_widget_delete.c
@@ -138,9 +138,10 @@ GX_EVENT delete_event;
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                       Lock access to GUIX           */
+/*    GX_ENTER_CRITICAL                     Lock access to GUIX           */
 /*    _gx_widget_delete_helper              Safely delete widget instance */
 /*    _gx_widget_free                       Free memory owned by widget   */
+/*    GX_EXIT_CRITICAL                      Release the protection        */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */

--- a/common/src/gx_widget_detach.c
+++ b/common/src/gx_widget_detach.c
@@ -53,10 +53,10 @@
 /*                                                                        */
 /*  CALLS                                                                 */
 /*                                                                        */
-/*    _gx_system_lock                        Lock access to GUIX          */
+/*    GX_ENTER_CRITICAL                      Lock access to GUIX          */
 /*    _gx_widget_hide                        Hide the widget              */
 /*    _gx_widget_unlink                      Unlink the widget            */
-/*    _gx_system_unlock                      Release the protection       */
+/*    GX_EXIT_CRITICAL                       Release the protection       */
 /*                                                                        */
 /*  CALLED BY                                                             */
 /*                                                                        */


### PR DESCRIPTION
replaced `_gx_system_lock` and `_gx_system_unlock` with `GX_ENTER_CRITICAL` and `GX_EXIT_CRITICAL`.

This change mainly effects `gx_horizontal_list_total_columns_set.c` and `gx_vertical_list_total_rows_set.c`.
All other changes are only in comments.