### PR TITLE
Fixed issue where IAR compiler cannot find associated function prototype when function parameter is empty

### DIFF
--- a/common/inc/gx_rich_text_view.h
+++ b/common/inc/gx_rich_text_view.h
@@ -59,11 +59,11 @@ typedef struct GX_RICH_TEXT_LINE_INFO_STRUCT
 
 /* Define rich text view management function prototypes. */
 UINT _gx_rich_text_view_context_peek(GX_RICH_TEXT_CONTEXT *context);
-UINT _gx_rich_text_view_context_pop();
+UINT _gx_rich_text_view_context_pop(VOID);
 UINT _gx_rich_text_view_context_push(GX_RICH_TEXT_CONTEXT *context);
-UINT _gx_rich_text_view_context_save();
-UINT _gx_rich_text_view_context_reset();
-UINT _gx_rich_text_view_context_restore();
+UINT _gx_rich_text_view_context_save(VOID);
+UINT _gx_rich_text_view_context_reset(VOID);
+UINT _gx_rich_text_view_context_restore(VOID);
 UINT _gx_rich_text_view_create(GX_RICH_TEXT_VIEW *text_view,
                                GX_CONST GX_CHAR *name,
                                GX_WIDGET *parent,

--- a/common/src/gx_rich_text_view_context_pop.c
+++ b/common/src/gx_rich_text_view_context_pop.c
@@ -65,7 +65,7 @@
 /*  09-30-2020     Kenneth Maxwell          Initial Version 6.1           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _gx_rich_text_view_context_pop()
+UINT  _gx_rich_text_view_context_pop(VOID)
 {
     if (_gx_system_rich_text_context_stack.gx_rich_text_context_stack_top <= 0)
     {

--- a/common/src/gx_rich_text_view_context_reset.c
+++ b/common/src/gx_rich_text_view_context_reset.c
@@ -64,7 +64,7 @@
 /*  09-30-2020     Kenneth Maxwell          Initial Version 6.1           */
 /*                                                                        */
 /**************************************************************************/
-UINT _gx_rich_text_view_context_reset()
+UINT _gx_rich_text_view_context_reset(VOID)
 {
     _gx_system_rich_text_context_stack.gx_rich_text_context_stack_top = 0;
 

--- a/common/src/gx_rich_text_view_context_restore.c
+++ b/common/src/gx_rich_text_view_context_restore.c
@@ -64,7 +64,7 @@
 /*  09-30-2020     Kenneth Maxwell          Initial Version 6.1           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _gx_rich_text_view_context_restore()
+UINT  _gx_rich_text_view_context_restore(VOID)
 {
 GX_UBYTE top = _gx_system_rich_text_context_stack_save.gx_rich_text_context_stack_top;
 

--- a/common/src/gx_rich_text_view_context_save.c
+++ b/common/src/gx_rich_text_view_context_save.c
@@ -64,7 +64,7 @@
 /*  09-30-2020     Kenneth Maxwell          Initial Version 6.1           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _gx_rich_text_view_context_save()
+UINT  _gx_rich_text_view_context_save(VOID)
 {
 GX_UBYTE top = _gx_system_rich_text_context_stack.gx_rich_text_context_stack_top;
 


### PR DESCRIPTION
IAR could not find associated function prototype when function parameter is empty.
I just added `void` into the brackets to fix this.