### PR TITLE
Fixed missing configuration check "#ifdef GX_BINARY_RESOURCE_SUPPORT"

### DIFF
--- a/common/src/gx_binres_font_load.c
+++ b/common/src/gx_binres_font_load.c
@@ -77,6 +77,7 @@
 /*  10-31-2023     Ting Zhu                 Initial Version 6.3.0         */
 /*                                                                        */
 /**************************************************************************/
+#ifdef GX_BINARY_RESOURCE_SUPPORT
 UINT _gx_binres_font_load(GX_UBYTE *root_address, UINT font_index, GX_UBYTE *buffer, ULONG *buffer_size)
 {
 UINT                status = GX_SUCCESS;
@@ -136,4 +137,4 @@ UINT                required_size;
 
     return status;
 }
-
+#endif

--- a/common/src/gx_binres_pixelmap_load.c
+++ b/common/src/gx_binres_pixelmap_load.c
@@ -66,6 +66,7 @@
 /*  10-31-2023     Ting Zhu                 Initial Version 6.3.0         */
 /*                                                                        */
 /**************************************************************************/
+#ifdef GX_BINARY_RESOURCE_SUPPORT
 UINT _gx_binres_standalone_resource_seek(GX_BINRES_DATA_INFO *info, UINT res_index)
 {
 USHORT type;
@@ -97,6 +98,7 @@ ULONG  count;
 
     return GX_SUCCESS;
 }
+#endif
 
 /**************************************************************************/
 /*                                                                        */
@@ -141,6 +143,7 @@ ULONG  count;
 /*  10-31-2023     Ting Zhu                 Initial Version 6.3.0         */
 /*                                                                        */
 /**************************************************************************/
+#ifdef GX_BINARY_RESOURCE_SUPPORT
 UINT _gx_binres_pixelmap_load(GX_UBYTE *root_address, UINT map_index, GX_PIXELMAP *pixelmap)
 {
 UINT                status = GX_SUCCESS;
@@ -184,4 +187,4 @@ GX_BINRES_DATA_INFO info;
 
     return status;
 }
-
+#endif

--- a/common/src/gxe_binres_font_load.c
+++ b/common/src/gxe_binres_font_load.c
@@ -76,6 +76,7 @@
 /*  10-31-2023     Ting Zhu                 Initial Version 6.3.0         */
 /*                                                                        */
 /**************************************************************************/
+#ifdef GX_BINARY_RESOURCE_SUPPORT
 UINT _gxe_binres_font_load(GX_UBYTE *root_address, UINT font_index, GX_UBYTE *buffer, ULONG *buffer_size)
 {
     if (root_address == GX_NULL || buffer == GX_NULL || buffer_size == GX_NULL)
@@ -85,4 +86,4 @@ UINT _gxe_binres_font_load(GX_UBYTE *root_address, UINT font_index, GX_UBYTE *bu
 
     return _gx_binres_font_load(root_address, font_index, buffer, buffer_size);
 }
-
+#endif

--- a/common/src/gxe_binres_pixelmap_load.c
+++ b/common/src/gxe_binres_pixelmap_load.c
@@ -71,6 +71,7 @@
 /*  10-31-2023     Ting Zhu                 Initial Version 6.3.0         */
 /*                                                                        */
 /**************************************************************************/
+#ifdef GX_BINARY_RESOURCE_SUPPORT
 UINT _gxe_binres_pixelmap_load(GX_UBYTE *root_address, UINT map_index, GX_PIXELMAP *pixelmap)
 {
     if (root_address == GX_NULL || pixelmap == GX_NULL)
@@ -80,4 +81,4 @@ UINT _gxe_binres_pixelmap_load(GX_UBYTE *root_address, UINT map_index, GX_PIXELM
 
     return _gx_binres_pixelmap_load(root_address, map_index, pixelmap);
 }
-
+#endif


### PR DESCRIPTION
When adding all files in `guix/common/src` to a project and setting `#define GX_DISABLE_BINARY_RESOURCE_SUPPORT` in `gx_user.h` I got errors that could be fixed by adding these include guards.
(I just added in these files what already existed in other files.)