### PR TITLE
Fixed missing configuration check "#if (GX_ANIMATION_POOL_SIZE > 0)"

### DIFF
--- a/common/inc/gx_animation.h
+++ b/common/inc/gx_animation.h
@@ -52,6 +52,7 @@
 #ifndef GX_ANIMATION_H
 #define GX_ANIMATION_H
 
+#if (GX_ANIMATION_POOL_SIZE > 0)
 #define GX_ANIMATION_SLIDE_LEFT       0x0001
 #define GX_ANIMATION_SLIDE_RIGHT      0x0002
 #define GX_ANIMATION_SLIDE_UP         0x0040
@@ -91,5 +92,6 @@ UINT _gxe_animation_stop(GX_ANIMATION *animation);
 
 UINT _gxe_animation_landing_speed_set(GX_ANIMATION *animation, USHORT shift_per_step);
 
+#endif
 #endif
 

--- a/common/inc/gx_api.h
+++ b/common/inc/gx_api.h
@@ -5714,8 +5714,10 @@ UINT _gxe_string_scroll_wheel_string_list_set_ext(GX_STRING_SCROLL_WHEEL *wheel,
                                                   INT string_count);
 
 UINT _gxe_system_active_language_set(GX_UBYTE language);
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_system_animation_get(GX_ANIMATION **animation);
 UINT _gxe_system_animation_free(GX_ANIMATION *animation);
+#endif
 #if defined(GX_DYNAMIC_BIDI_TEXT_SUPPORT)
 UINT _gx_system_bidi_text_enable(VOID);
 UINT _gx_system_bidi_text_disable(VOID);

--- a/common/src/gx_animation_canvas_define.c
+++ b/common/src/gx_animation_canvas_define.c
@@ -73,6 +73,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_canvas_define(GX_ANIMATION *animation, GX_CANVAS *canvas)
 {
     if (animation -> gx_animation_status != GX_ANIMATION_IDLE)
@@ -85,4 +86,4 @@ UINT  _gx_animation_canvas_define(GX_ANIMATION *animation, GX_CANVAS *canvas)
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_complete.c
+++ b/common/src/gx_animation_complete.c
@@ -71,6 +71,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 VOID _gx_animation_complete_event_send(GX_ANIMATION *animation)
 {
 GX_EVENT complete_event;
@@ -93,7 +94,7 @@ GX_EVENT complete_event;
         _gx_system_event_send(&complete_event);
     }
 }
-
+#endif
 
 
 /**************************************************************************/
@@ -146,7 +147,7 @@ GX_EVENT complete_event;
 /*                                            resulting in version 6.1.3  */
 /*                                                                        */
 /**************************************************************************/
-
+#if (GX_ANIMATION_POOL_SIZE > 0)
 VOID _gx_animation_complete(GX_ANIMATION *animation)
 {
 GX_WIDGET *target;
@@ -255,4 +256,4 @@ GX_VALUE   yshift;
         _gx_system_animation_free(animation);
     }
 }
-
+#endif

--- a/common/src/gx_animation_create.c
+++ b/common/src/gx_animation_create.c
@@ -70,6 +70,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_create(GX_ANIMATION *animation)
 {
     memset(animation, 0, sizeof(GX_ANIMATION));
@@ -79,4 +80,4 @@ UINT  _gx_animation_create(GX_ANIMATION *animation)
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_delete.c
+++ b/common/src/gx_animation_delete.c
@@ -71,7 +71,7 @@
 /*  06-02-2021     Ting Zhu                 Initial Version 6.1.7         */
 /*                                                                        */
 /**************************************************************************/
-
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gx_animation_delete(GX_ANIMATION *target, GX_WIDGET *parent)
 {
 GX_ANIMATION *animation;
@@ -122,4 +122,4 @@ GX_ANIMATION *next;
 
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_drag_disable.c
+++ b/common/src/gx_animation_drag_disable.c
@@ -70,6 +70,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_drag_disable(GX_ANIMATION *animation, GX_WIDGET *widget)
 {
 UINT status;
@@ -82,4 +83,4 @@ UINT status;
     status =  _gx_animation_stop(animation);
     return status;
 }
-
+#endif

--- a/common/src/gx_animation_drag_enable.c
+++ b/common/src/gx_animation_drag_enable.c
@@ -71,6 +71,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_drag_enable(GX_ANIMATION *animation, GX_WIDGET *widget, GX_ANIMATION_INFO *info)
 {
     /* Test invalid animation status. */
@@ -93,4 +94,4 @@ UINT  _gx_animation_drag_enable(GX_ANIMATION *animation, GX_WIDGET *widget, GX_A
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_drag_event_process.c
+++ b/common/src/gx_animation_drag_event_process.c
@@ -85,6 +85,7 @@
 /*                                            resulting in version 6.1.8  */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 static UINT  _gx_animation_drag_event_check(GX_ANIMATION *animation, GX_EVENT *event_ptr)
 {
 GX_ANIMATION_INFO *info = &animation -> gx_animation_info;
@@ -277,6 +278,7 @@ INT                shift;
 
     return GX_SUCCESS;
 }
+#endif
 
 /**************************************************************************/
 /*                                                                        */
@@ -320,6 +322,7 @@ INT                shift;
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_drag_event_process(GX_WIDGET *widget, GX_EVENT *event_ptr)
 {
 GX_ANIMATION *animation;
@@ -342,4 +345,4 @@ GX_ANIMATION *animation;
 
     return GX_SUCCESS;
 }
-
+#endif

--- a/common/src/gx_animation_drag_tracking.c
+++ b/common/src/gx_animation_drag_tracking.c
@@ -78,6 +78,7 @@
 /*                                            resulting in version 6.1.11 */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_drag_tracking(GX_ANIMATION *animation, GX_POINT penpos)
 {
 GX_VALUE     delta_x = 0;
@@ -221,4 +222,4 @@ GX_VALUE     border_width;
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_drag_tracking_start.c
+++ b/common/src/gx_animation_drag_tracking_start.c
@@ -73,6 +73,7 @@
 /*                                            resulting in version 6.1.11 */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_drag_tracking_start(GX_ANIMATION *animation, GX_POINT penpos)
 {
 GX_ANIMATION_INFO *info;
@@ -305,4 +306,4 @@ VOID               (*active_display_area_set)(INT layer, GX_RECTANGLE *size);
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_landing_speed_set.c
+++ b/common/src/gx_animation_landing_speed_set.c
@@ -70,6 +70,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_landing_speed_set(GX_ANIMATION *animation, USHORT shift_per_step)
 {
     animation -> gx_animation_landing_speed = shift_per_step;
@@ -77,4 +78,4 @@ UINT  _gx_animation_landing_speed_set(GX_ANIMATION *animation, USHORT shift_per_
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_slide_landing.c
+++ b/common/src/gx_animation_slide_landing.c
@@ -79,6 +79,7 @@
 /*                                            resulting in version 6.1.11 */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_slide_landing(GX_ANIMATION *animation)
 {
 GX_ANIMATION_INFO *info = &animation -> gx_animation_info;
@@ -296,4 +297,4 @@ GX_VALUE           border_width;
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_slide_landing_start.c
+++ b/common/src/gx_animation_slide_landing_start.c
@@ -73,6 +73,7 @@
 /*                                            resulting in version 6.1.11 */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gx_animation_slide_landing_start(GX_ANIMATION *animation)
 {
 GX_ANIMATION_INFO *info;
@@ -119,4 +120,4 @@ GX_RECTANGLE      *target_size;
     /* Return completion status code. */
     return(GX_SUCCESS);
 }
-
+#endif

--- a/common/src/gx_animation_start.c
+++ b/common/src/gx_animation_start.c
@@ -85,6 +85,7 @@
 /*                                            resulting in version 6.1.3  */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gx_animation_start(GX_ANIMATION *animation, GX_ANIMATION_INFO *info)
 {
 UINT            status = GX_SUCCESS;
@@ -207,4 +208,4 @@ GX_VALUE top;
 
     return(status);
 }
-
+#endif

--- a/common/src/gx_animation_stop.c
+++ b/common/src/gx_animation_stop.c
@@ -76,6 +76,7 @@
 /*                                            resulting in version 6.1.3  */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gx_animation_stop(GX_ANIMATION *animation)
 {
 UINT          status = GX_SUCCESS;
@@ -123,4 +124,4 @@ GX_ANIMATION *previous;
     GX_EXIT_CRITICAL
     return(status);
 }
-
+#endif

--- a/common/src/gx_animation_update.c
+++ b/common/src/gx_animation_update.c
@@ -81,6 +81,7 @@
 /*                                            resulting in version 6.1.11 */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 VOID _gx_animation_update(VOID)
 {
 GX_ANIMATION      *animation;
@@ -245,4 +246,4 @@ GX_RECTANGLE       block;
         animation = next;
     }
 }
-
+#endif

--- a/common/src/gx_system_timer_update.c
+++ b/common/src/gx_system_timer_update.c
@@ -127,10 +127,12 @@ GX_ENTER_CRITICAL
         current_timer = next_timer;
     }
 
+#if (GX_ANIMATION_POOL_SIZE > 0)
     if (_gx_system_animation_list)
     {
         _gx_animation_update();
     }
+#endif
 
     /* release our lock */
     GX_EXIT_CRITICAL

--- a/common/src/gxe_animation_canvas_define.c
+++ b/common/src/gxe_animation_canvas_define.c
@@ -72,6 +72,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gxe_animation_canvas_define(GX_ANIMATION *animation, GX_CANVAS *canvas)
 {
 UINT  status = GX_SUCCESS;
@@ -103,4 +104,4 @@ ULONG required_size;
     /* Return completion status code. */
     return(status);
 }
-
+#endif

--- a/common/src/gxe_animation_create.c
+++ b/common/src/gxe_animation_create.c
@@ -66,6 +66,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT  _gxe_animation_create(GX_ANIMATION *animation)
 {
 UINT status;
@@ -87,4 +88,4 @@ UINT status;
     /* Return completion status.  */
     return(status);
 }
-
+#endif

--- a/common/src/gxe_animation_delete.c
+++ b/common/src/gxe_animation_delete.c
@@ -69,6 +69,7 @@ GX_CALLER_CHECKING_EXTERNS
 /*  06-02-2021     Ting Zhu                 Initial Version 6.1.7         */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_delete(GX_ANIMATION *target, GX_WIDGET *parent)
 {
     /* Check for appropriate caller.  */
@@ -81,4 +82,4 @@ UINT _gxe_animation_delete(GX_ANIMATION *target, GX_WIDGET *parent)
 
     return _gx_animation_delete(target, parent);
 }
-
+#endif

--- a/common/src/gxe_animation_drag_disable.c
+++ b/common/src/gxe_animation_drag_disable.c
@@ -73,6 +73,7 @@ GX_CALLER_CHECKING_EXTERNS
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_drag_disable(GX_ANIMATION *animation, GX_WIDGET *widget)
 {
     /* Check for appropriate caller.  */
@@ -92,4 +93,4 @@ UINT _gxe_animation_drag_disable(GX_ANIMATION *animation, GX_WIDGET *widget)
 
     return _gx_animation_drag_disable(animation, widget);
 }
-
+#endif

--- a/common/src/gxe_animation_drag_enable.c
+++ b/common/src/gxe_animation_drag_enable.c
@@ -72,6 +72,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_drag_enable(GX_ANIMATION *animation, GX_WIDGET *widget, GX_ANIMATION_INFO *info)
 {
     /* Check for invalid pointer. */
@@ -107,4 +108,4 @@ UINT _gxe_animation_drag_enable(GX_ANIMATION *animation, GX_WIDGET *widget, GX_A
 
     return(_gx_animation_drag_enable(animation, widget, info));
 }
-
+#endif

--- a/common/src/gxe_animation_landing_speed_set.c
+++ b/common/src/gxe_animation_landing_speed_set.c
@@ -70,6 +70,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_landing_speed_set(GX_ANIMATION *animation, USHORT shift_per_step)
 {
     /* Check for invalid input pointers.  */
@@ -85,4 +86,4 @@ UINT _gxe_animation_landing_speed_set(GX_ANIMATION *animation, USHORT shift_per_
 
     return _gx_animation_landing_speed_set(animation, shift_per_step);
 }
-
+#endif

--- a/common/src/gxe_animation_start.c
+++ b/common/src/gxe_animation_start.c
@@ -80,6 +80,7 @@ GX_CALLER_CHECKING_EXTERNS
 /*                                            resulting in version 6.3.0  */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_start(GX_ANIMATION *animation, GX_ANIMATION_INFO *info)
 {
     /* Check for appropriate caller.  */
@@ -120,4 +121,4 @@ UINT _gxe_animation_start(GX_ANIMATION *animation, GX_ANIMATION_INFO *info)
 
     return(_gx_animation_start(animation, info));
 }
-
+#endif

--- a/common/src/gxe_animation_stop.c
+++ b/common/src/gxe_animation_stop.c
@@ -73,6 +73,7 @@ GX_CALLER_CHECKING_EXTERNS
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
+#if (GX_ANIMATION_POOL_SIZE > 0)
 UINT _gxe_animation_stop(GX_ANIMATION *animation)
 {
     /* Check for appropriate caller.  */
@@ -90,4 +91,4 @@ UINT _gxe_animation_stop(GX_ANIMATION *animation)
 
     return _gx_animation_stop(animation);
 }
-
+#endif


### PR DESCRIPTION
This was found when setting `#define GX_ANIMATION_POOL_SIZE 0` in `gx_user.h` for some resource constrained system.

My projected compiled fine with `#define GX_ANIMATION_POOL_SIZE 1` but I had to make the changes contained in this PR in order to be able to compile with `#define GX_ANIMATION_POOL_SIZE 0`.

(Just like in one of my previous PRs I just copied what already existed in other files.)