### PR TITLE
added missing status return value.

### DIFF
--- a/common/src/gx_system_event_send.c
+++ b/common/src/gx_system_event_send.c
@@ -99,7 +99,7 @@ GX_WIDGET *target = GX_NULL;
         status = GX_SUCCESS;
     }
 #else
-    GX_EVENT_PUSH(in_event);
+    status = GX_EVENT_PUSH(in_event);
 #endif
 
     if (check_send_flick)


### PR DESCRIPTION
This fixes _gx_system_event_send() to falsely return GX_SYSTEM_ERROR if GX_DISABLE_THREADX_BINDING is defined.