### PR TITLE
added hook for error processing

### DIFF
--- a/common/inc/gx_system_rtos_bind.h
+++ b/common/inc/gx_system_rtos_bind.h
@@ -82,6 +82,9 @@ VOID  gx_generic_system_mutex_unlock(VOID);
 ULONG gx_generic_system_time_get(VOID);
 VOID *gx_generic_thread_identify(VOID);
 VOID  gx_generic_time_delay(INT ticks);
+#ifdef GX_ENABLE_ERROR_CALLBACK
+VOID  gx_generic_error_process(UINT error_code, ULONG error_count);
+#endif
 
 
 #define GX_RTOS_BINDING_INITIALIZE gx_generic_rtos_initialize()
@@ -97,7 +100,9 @@ VOID  gx_generic_time_delay(INT ticks);
 #define GX_SYSTEM_TIME_GET         gx_generic_system_time_get()
 #define GX_CURRENT_THREAD          gx_generic_thread_identify()
 #define GX_GENERIC_TIME_DELAY(a)   gx_generic_time_delay(a)
-
+#ifdef GX_ENABLE_ERROR_CALLBACK
+#define GX_GENERIC_ERROR_PROCESS   gx_generic_error_process
+#endif
 
 
 #endif

--- a/common/src/gx_system_error_process.c
+++ b/common/src/gx_system_error_process.c
@@ -71,5 +71,11 @@ VOID  _gx_system_error_process(UINT error_code)
 
     /* Remember the last system error code.  */
     _gx_system_last_error =  error_code;
+
+#ifdef GX_DISABLE_THREADX_BINDING
+#ifdef GX_ENABLE_ERROR_CALLBACK
+    GX_GENERIC_ERROR_PROCESS(error_code, _gx_system_error_count);
+#endif
+#endif
 }
 


### PR DESCRIPTION
This is related to https://github.com/eclipse-threadx/guix/issues/148#issuecomment-4572676478.

If GX_DISABLE_THREADX_BINDING is defined this gives the option to also define GX_ENABLE_ERROR_CALLBACK to activate another function call for custom RTOS bindings: `VOID  gx_generic_error_process(UINT error_code, ULONG error_count);`

As mentioned in the linked issue-comment this hook could be used to call something like `vTaskCustomSuspend(guix_task_handle);` on a FreeRTOS system to keep GUIX from potentially breaking the whole FreeRTOS system by suspending the GUIX task.

Feel free to change this code before merging e.g. if you prefer to have this option independently of GX_DISABLE_THREADX_BINDING or if my proposal messes up some GUIX principle that I was not aware of. 
I'd just like to have something in the GUIX library to immediately suspend the GUIX task at this point.