### PR TITLE
Added compile-time warning for GUIX deprecated string API

### DIFF
--- a/common/inc/gx_api.h
+++ b/common/inc/gx_api.h
@@ -132,6 +132,10 @@ typedef struct GX_STRING_STRUCT
 
 #ifndef GX_DISABLE_DEPRECATED_STRING_API
 #define GX_ENABLE_DEPRECATED_STRING_API
+#pragma message("GUIX deprecated string API is enabled. The pre-5.6 char* string " \
+                "functions do not carry a length and are unsafe with non-NUL-terminated " \
+                "buffers. Define GX_DISABLE_DEPRECATED_STRING_API and migrate to the " \
+                "GX_STRING-based (_ext) variants.")
 #endif
 
 #if defined(GX_THREADX_BINDING)


### PR DESCRIPTION
## Summary
When `GX_DISABLE_DEPRECATED_STRING_API` is not defined, `gx_api.h` now emits a `#pragma message` compile-time warning directing developers to define `GX_DISABLE_DEPRECATED_STRING_API` and migrate to the `GX_STRING`-based (`_ext`) replacement functions.

The pre-5.6 `GX_CHAR *` API omits string lengths and cannot safely handle non-NUL-terminated strings or prevent buffer overruns. All new applications should use the replacement variants.

## Changes
- `common/inc/gx_api.h`: added `#pragma message` inside the `#ifndef GX_DISABLE_DEPRECATED_STRING_API` block.

## Companion
Docs: eclipse-threadx/rtos-docs-asciidoc#33 (pending)